### PR TITLE
Fixed deprecation notice

### DIFF
--- a/start.js
+++ b/start.js
@@ -29,8 +29,7 @@ app.on('ready', function() {
     mainWindow.maximize();
 
     // and load the index.html of the app.
-    mainWindow.loadUrl('file://' + __dirname + '/index.html');
-
+    mainWindow.loadURL('file://' + __dirname + '/index.html');
     // Open the devtools.
     //mainWindow.openDevTools();
 


### PR DESCRIPTION
A quick one line fix for getting rid of the 'loadUrl' deprecation notice in the terminal when starting an electron session. 
